### PR TITLE
Per route redirect

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -18,7 +18,11 @@ server.register([
         '/test': '/it/works',
         '/something/else': '/it/works',
         '/': '/it/works?test=1',
-        '/test/{param*2}': '/newtest/{param*2}'
+        '/test/{param*2}': '/newtest/{param*2}',
+        '/test302': {
+          path: '/it/works',
+          redirectType: 302
+        }
       },
       vhosts: {
         'blahblah.com.localhost': {

--- a/example/index.js
+++ b/example/index.js
@@ -20,8 +20,8 @@ server.register([
         '/': '/it/works?test=1',
         '/test/{param*2}': '/newtest/{param*2}',
         '/test302': {
-          path: '/it/works',
-          redirectType: 302
+          destination: '/it/works',
+          statusCode: 302
         }
       },
       vhosts: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ module.exports = (server, options, next) => {
   const redirector = (request, reply) => {
     const routePath = request.route.path;
     const vhost = request.route.settings.vhost;
-    let redirectTo = lookupRedirectsByVhost[vhost][routePath];
+    let redirectTo = lookupRedirectsByVhost[vhost][routePath].dest;
     _.each(request.params, (param, paramName) => {
       redirectTo = replaceRouteParamWithValues(redirectTo, paramName, param);
     });
@@ -52,12 +52,12 @@ module.exports = (server, options, next) => {
           to: redirectTo
         });
       }
-      return reply.redirect(redirectTo).code(options.statusCode);
+      return reply.redirect(redirectTo).code(lookupRedirectsByVhost[vhost][routePath].statusCode);
     }
     server.log(['hapi-redirects', 'error'], { path: request.path, vhost });
     reply(new Error('invalid redirect'));
   };
-  const registerRoute = (path, vhost, dest) => {
+  const registerRoute = (path, vhost, dest, statusCode) => {
     const routeDefinition = {
       path,
       method: 'GET',
@@ -71,7 +71,7 @@ module.exports = (server, options, next) => {
     if (!lookupRedirectsByVhost[vhost]) {
       lookupRedirectsByVhost[vhost] = {};
     }
-    lookupRedirectsByVhost[vhost][path] = dest;
+    lookupRedirectsByVhost[vhost][path] = { dest, statusCode };
     if (options.verbose) {
       server.log(['hapi-redirects', 'debug'], {
         message: 'registering route',
@@ -82,7 +82,13 @@ module.exports = (server, options, next) => {
   const registerRoutes = (routeList, vhost) => {
     const routes = [];
     _.each(routeList, (v, route) => {
-      routes.push(registerRoute(route, vhost, routeList[route]));
+      let statusCode = options.statusCode;
+      if (typeof v === 'object') {
+        statusCode = v.statusCode !== undefined ? v.statusCode : options.statusCode;
+        routes.push(registerRoute(route, vhost, v.destination, statusCode));
+      } else {
+        routes.push(registerRoute(route, vhost, routeList[route], statusCode));
+      }
     });
     return routes;
   };

--- a/test/redirects.test.js
+++ b/test/redirects.test.js
@@ -72,7 +72,6 @@ lab.experiment('hapi-redirect', () => {
       });
     });
   });
-
   lab.test(' / -> /it/works?test=1', (done) => {
     server.register({
       register: redirectModule,
@@ -303,6 +302,31 @@ lab.experiment('hapi-redirect', () => {
             Code.expect(result.headers.location).to.equal('/newtest');
             done();
           });
+        });
+      });
+    });
+  });
+  lab.test(' /test -> /it/works   /something/else -> /it/works', (done) => {
+    server.register({
+      register: redirectModule,
+      options: {
+        redirects: {
+          '/test302': {
+            destination: '/it/works',
+            statusCode: 302
+          }
+        },
+      }
+    },
+    () => {
+      server.start(() => {
+        server.inject({
+          method: 'get',
+          url: '/test302'
+        }, (result) => {
+          Code.expect(result.statusCode).to.equal(302);
+          Code.expect(result.headers.location).to.equal('/it/works');
+          done();
         });
       });
     });

--- a/test/redirects.test.js
+++ b/test/redirects.test.js
@@ -188,29 +188,6 @@ lab.experiment('hapi-redirect', () => {
     });
   });
 
-  lab.test('set default status code', (done) => {
-    server.register({
-      register: redirectModule,
-      options: {
-        statusCode: 302,
-        redirects: {
-          '/': '/it/works',
-        },
-      }
-    },
-    () => {
-      server.start(() => {
-        server.inject({
-          method: 'get',
-          url: '/'
-        }, (result) => {
-          Code.expect(result.statusCode).to.equal(302);
-          done();
-        });
-      });
-    });
-  });
-
   lab.test(' /test/{params*2} -> /newtest/{param*2}', (done) => {
     server.register({
       register: redirectModule,
@@ -306,7 +283,31 @@ lab.experiment('hapi-redirect', () => {
       });
     });
   });
-  lab.test(' /test -> /it/works   /something/else -> /it/works', (done) => {
+
+  lab.test('set default status code', (done) => {
+    server.register({
+      register: redirectModule,
+      options: {
+        statusCode: 302,
+        redirects: {
+          '/': '/it/works',
+        },
+      }
+    },
+    () => {
+      server.start(() => {
+        server.inject({
+          method: 'get',
+          url: '/'
+        }, (result) => {
+          Code.expect(result.statusCode).to.equal(302);
+          done();
+        });
+      });
+    });
+  });
+
+  lab.test(' set status code for specific route (without params)', (done) => {
     server.register({
       register: redirectModule,
       options: {
@@ -326,6 +327,70 @@ lab.experiment('hapi-redirect', () => {
         }, (result) => {
           Code.expect(result.statusCode).to.equal(302);
           Code.expect(result.headers.location).to.equal('/it/works');
+          done();
+        });
+      });
+    });
+  });
+
+  lab.test(' set status code for specific route (with params)', (done) => {
+    server.register({
+      register: redirectModule,
+      options: {
+        redirects: {
+          '/test/{param*2}': {
+            destination: '/newtest/{param*2}',
+            statusCode: 302
+          }
+        },
+      }
+    },
+    () => {
+      server.start(() => {
+        server.inject({
+          method: 'get',
+          url: '/test/param1/param2',
+          headers: {
+            Host: 'en.example.com'
+          },
+        }, (result) => {
+          Code.expect(result.statusCode).to.equal(302);
+          Code.expect(result.headers.location).to.equal('/newtest/param1/param2');
+          done();
+        });
+      });
+    });
+  });
+
+  lab.test(' set status code for specific route (with vhost) ', (done) => {
+    server.register({
+      register: redirectModule,
+      options: {
+        log: true,
+        log404: true,
+        vhosts: {
+          'blahblah.com.localhost': {
+            '/test': {
+                destination: '/newtest',
+                statusCode: 302
+            },
+            '/post/(.*)/': '/newtest',
+            '/*': '/newtest',
+          }
+        }
+      }
+    },
+    () => {
+      server.start(() => {
+        server.inject({
+          method: 'get',
+          url: '/test',
+          headers: {
+            Host: 'blahblah.com.localhost'
+          }
+        }, (result) => {
+          Code.expect(result.statusCode).to.equal(302);
+          Code.expect(result.headers.location).to.equal('/newtest');
           done();
         });
       });

--- a/test/redirects.test.js
+++ b/test/redirects.test.js
@@ -312,6 +312,7 @@ lab.experiment('hapi-redirect', () => {
       register: redirectModule,
       options: {
         redirects: {
+          '/test301': '/it/works',
           '/test302': {
             destination: '/it/works',
             statusCode: 302
@@ -327,7 +328,14 @@ lab.experiment('hapi-redirect', () => {
         }, (result) => {
           Code.expect(result.statusCode).to.equal(302);
           Code.expect(result.headers.location).to.equal('/it/works');
-          done();
+          server.inject({
+            method: 'get',
+            url: '/test301'
+          }, (result) => {
+            Code.expect(result.statusCode).to.equal(301);
+            Code.expect(result.headers.location).to.equal('/it/works');
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
redirects can be specified either the old way (as a string) or as an object like so:

'/test': {
       destination: '/newtest',
       statusCode: 302
}